### PR TITLE
Correction according to betty format and some changes to the default switch case

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -58,8 +58,7 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			break;
 		default:
 			*count += _putchar('%');
-			*count += _putchar(format[*i + 1]);
-			exit(EXIT_FAILURE);
+			++*i;
 			break;
 	}
 }

--- a/_printf.c
+++ b/_printf.c
@@ -62,7 +62,6 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			*i += 2;
 			break;
 		case ' ':
-			*count += _prints(va_arg(list, char *));
 			*error = 1;
 			++*i;
 			break;

--- a/_printf.c
+++ b/_printf.c
@@ -24,7 +24,7 @@ int _printf(const char *format, ...)
 			{
 				select_command(format, list, pointer_i, pointer_count, pointer_error);
 				if (error == 1)
-					return error;
+					return count;
 			}
 			else
 			{

--- a/_printf.c
+++ b/_printf.c
@@ -32,6 +32,7 @@ int _printf(const char *format, ...)
 				++i;
 			}
 		}
+		va_end(list);
 	}
 	return (count);
 }
@@ -77,11 +78,6 @@ void select_command(const char *format, va_list list, int *i, int *count,
 				*error = 1;
 			}
 			*i += 2;
-			break;
-		default:
-			*count += _putchar('%');
-			*error = 0;
-			++*i;
 			break;
 	}
 }

--- a/_printf.c
+++ b/_printf.c
@@ -18,7 +18,7 @@ int _printf(const char *format, ...)
 	va_start(list, format);
 	if (format)
 	{
-		while (format[i])
+		while (format[i] != '\0')
 		{
 			if (format[i] == '%')
 			{

--- a/_printf.c
+++ b/_printf.c
@@ -80,7 +80,8 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			*i += 2;
 			break;
 		default:
-			++*i;
+			_putchar('%');
+			*error = 1;
 	}
 }
 /**

--- a/_printf.c
+++ b/_printf.c
@@ -63,7 +63,7 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			break;
 		default:
 			*count += _putchar('%');
-			*error = 1;
+			*error = 0;
 			++*i;
 			break;
 	}

--- a/_printf.c
+++ b/_printf.c
@@ -23,6 +23,8 @@ int _printf(const char *format, ...)
 			if (format[i] == '%')
 			{
 				select_command(format, list, pointer_i, pointer_count, pointer_error);
+				if (error == 1)
+					return error;
 			}
 			else
 			{

--- a/_printf.c
+++ b/_printf.c
@@ -61,8 +61,10 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			if (character != 0)
 				*count += _putchar(character);
 			else
+			{
 				_putchar('%');
 				*error = 1;
+			}
 			*i += 2;
 			break;
 		case 's':
@@ -70,14 +72,11 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			if (string != NULL)
 				*count += _prints(string);
 			else
+			{
 				_putchar('%');
 				*error = 1;
+			}
 			*i += 2;
-			break;
-		case ' ':
-			_putchar('%');
-			*error = 1;
-			++*i;
 			break;
 		default:
 			*count += _putchar('%');

--- a/_printf.c
+++ b/_printf.c
@@ -9,10 +9,11 @@
  */
 int _printf(const char *format, ...)
 {
-	int i = 0, count = 0;
+	int i = 0, count = 0, error = 0;
 	va_list list;
 	int *pointer_i = &i;
 	int *pointer_count = &count;
+	int *pointer_error = &error;
 
 	va_start(list, format);
 	if (format)
@@ -21,7 +22,9 @@ int _printf(const char *format, ...)
 		{
 			if (format[i] == '%')
 			{
-				select_command(format, list, pointer_i, pointer_count);
+				select_command(format, list, pointer_i, pointer_count, pointer_error);
+				if (error == 1)
+					exit(EXIT_FAILURE);
 			}
 			else
 			{
@@ -38,9 +41,11 @@ int _printf(const char *format, ...)
  * @i: int
  * @count: int
  * @list: list of arguments
+ * @error: error flag
  * Return: returns i
  */
-void select_command(const char *format, va_list list, int *i, int *count)
+void select_command(const char *format, va_list list, int *i, int *count,
+		int *error)
 {
 	switch (format[*i + 1])
 	{
@@ -58,14 +63,16 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			break;
 		case ' ':
 			*count += _putchar('%');
-			exit(EXIT_FAILURE);
+			*error = 1;
 			break;
 		case '\0':
 			*count += _putchar('%');
+			*error = 1;
 			++*i;
 			break;
 		default:
 			*count += _putchar('%');
+			*error = 1;
 			++*i;
 			break;
 	}

--- a/_printf.c
+++ b/_printf.c
@@ -57,12 +57,15 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*i += 2;
 			break;
 		case ' ':
+			*count += _putchar('%');
 			exit(EXIT_FAILURE);
 			break;
 		case '\0':
+			*count += _putchar('%');
 			++*i;
 			break;
 		default:
+			*count += _putchar('%');
 			++*i;
 			break;
 	}

--- a/_printf.c
+++ b/_printf.c
@@ -60,6 +60,9 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*count += _putchar('%');
 			exit(EXIT_FAILURE);
 			break;
+		case '\0':
+			exit(EXIT_FAILURE):
+			break;
 		default:
 			*count += _putchar('%');
 			++*i;

--- a/_printf.c
+++ b/_printf.c
@@ -56,11 +56,6 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*count += _prints(va_arg(list, char *));
 			*i += 2;
 			break;
-		case 'd':
-		case 'i':
-			_print_num(va_arg(list, int));
-			*i += 2;
-			break;
 		default:
 			exit(EXIT_FAILURE);
 			*i += 2;

--- a/_printf.c
+++ b/_printf.c
@@ -79,7 +79,7 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			}
 			*i += 2;
 			break;
-		case default:
+		default:
 			_putchar('%');
 			++*i;
 			*error = 1;

--- a/_printf.c
+++ b/_printf.c
@@ -58,7 +58,9 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			break;
 		default:
 			*count += _putchar('%');
-			++*i;
+			*count += _putchar(format[*i + 1]);
+			++*i; 
+			exit(EXIT_FAILURE);
 			break;
 	}
 }

--- a/_printf.c
+++ b/_printf.c
@@ -81,7 +81,6 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			break;
 		default:
 			++*i;
-			*error = 1;
 	}
 }
 /**

--- a/_printf.c
+++ b/_printf.c
@@ -79,6 +79,10 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			}
 			*i += 2;
 			break;
+		case default:
+			_putchar('%');
+			++*i;
+			*error = 1;
 	}
 }
 /**

--- a/_printf.c
+++ b/_printf.c
@@ -80,7 +80,6 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			*i += 2;
 			break;
 		default:
-			_putchar('%');
 			++*i;
 			*error = 1;
 	}

--- a/_printf.c
+++ b/_printf.c
@@ -57,14 +57,12 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*i += 2;
 			break;
 		case ' ':
-			*count += _putchar('%');
 			exit(EXIT_FAILURE);
 			break;
 		case '\0':
 			++*i;
 			break;
 		default:
-			*count += _putchar('%');
 			++*i;
 			break;
 	}

--- a/_printf.c
+++ b/_printf.c
@@ -61,6 +61,7 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			if (character != 0)
 				*count += _putchar(character);
 			else
+				_putchar('%');
 				*error = 1;
 			*i += 2;
 			break;
@@ -69,6 +70,7 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			if (string != NULL)
 				*count += _prints(string);
 			else
+				_putchar('%');
 				*error = 1;
 			*i += 2;
 			break;

--- a/_printf.c
+++ b/_printf.c
@@ -10,6 +10,8 @@ int _printf(const char *format, ...)
 {
 	int i = 0, count = 0;
 	va_list list;
+	int *pointer_i = &i;
+	int *pointer_count = &count;
 
 	va_start(list, format);
 	if (format)
@@ -18,7 +20,7 @@ int _printf(const char *format, ...)
 		{
 			if (format[i] == '%')
 			{
-				i = select_command(format, list, i, count);
+				select_command(format, list, pointer_i, pointer_count);
 			}
 			else
 			{
@@ -37,32 +39,31 @@ int _printf(const char *format, ...)
  * @list: list of arguments
  * Return: returns i
  */
-int select_command(const char *format, va_list list, int i, int count)
+void select_command(const char *format, va_list list, int *i, int *count)
 {
-	switch (format[i + 1])
+	switch (format[*i + 1])
 	{
 		case '%':
-			count += _putchar('%');
-			i += 2;
+			*count += _putchar('%');
+			*i += 2;
 			break;
 		case 'c':
-			count += _putchar(va_arg(list, int));
-			i += 2;
+			*count += _putchar(va_arg(list, int));
+			*i += 2;
 			break;
 		case 's':
-			count += _prints(va_arg(list, char *));
-			i += 2;
+			*count += _prints(va_arg(list, char *));
+			*i += 2;
 			break;
 		case 'd':
 		case 'i':
 			_print_num(va_arg(list, int));
-			i += 2;
+			*i += 2;
 			break;
 		default:
-			++i;
+			++*i;
 			break;
 	}
-	return (i);
 }
 /**
  *_putchar - prints a char

--- a/_printf.c
+++ b/_printf.c
@@ -2,42 +2,23 @@
 #include <stdarg.h>
 #include <stdio.h>
 /**
+ * _printf - function used for printing any value
+ * @format: Value to print along with specifiers
+ * Return: Returns the number of characters printed
  */
 int _printf(const char *format, ...)
 {
 	int i = 0, count = 0;
 	va_list list;
-	va_start(list, format);
 
-	if(format)
+	va_start(list, format);
+	if (format)
 	{
-		while(format[i])
+		while (format[i])
 		{
-		        if(format[i] == '%')
+			if (format[i] == '%')
 			{
-				switch(format[i + 1])
-				{
-				case '%':
-					count += _putchar('%');
-					i += 2;
-					break;
-				case 'c':
-					count += _putchar(va_arg(list,int));
-					i += 2;
-					break;
-				case 's':
-					count += _prints(va_arg(list, char *));
-					i += 2;
-					break;
-				case 'd':
-				case 'i':
-					_print_num(va_arg(list,int));
-					i += 2;
-					break;
-				default:
-					++i;
-					break;
-				}
+				i = select_command(format, list, i, count);
 			}
 			else
 			{
@@ -47,6 +28,41 @@ int _printf(const char *format, ...)
 		}
 	}
 	return (count);
+}
+/**
+ * select_command - prints the required arguments and returns i
+ * @format: values to be printed
+ * @i: int
+ * @count: int
+ * @list: list of arguments
+ * Return: returns i
+ */
+int select_command(const char *format, va_list list, int i, int count)
+{
+	switch (format[i + 1])
+	{
+		case '%':
+			count += _putchar('%');
+			i += 2;
+			break;
+		case 'c':
+			count += _putchar(va_arg(list, int));
+			i += 2;
+			break;
+		case 's':
+			count += _prints(va_arg(list, char *));
+			i += 2;
+			break;
+		case 'd':
+		case 'i':
+			_print_num(va_arg(list, int));
+			i += 2;
+			break;
+		default:
+			++i;
+			break;
+	}
+	return (i);
 }
 /**
  *_putchar - prints a char
@@ -60,10 +76,14 @@ int _putchar(char c)
 }
 
 /**
+ * _prints - prints a string
+ * @s: string to be printed
+ * Return: Returns int
  */
 int _prints(char *s)
 {       int c = 0;
-	while(*s != '\0')
+
+	while (*s != '\0')
 	{
 		c += _putchar(*s);
 		s++;
@@ -72,7 +92,7 @@ int _prints(char *s)
 }
 
 /**
-* print_number - prints # using _putchar function
+* _print_num - prints # using _putchar function
 * @n: the integer to print
 *
 * Return: void
@@ -81,6 +101,7 @@ void _print_num(int n)
 {
 	int copy, nth, size = 1, ones = n % 10;
 	int c = 0;
+
 	n /= 10;
 	copy = n;
 	if (ones < 0)

--- a/_printf.c
+++ b/_printf.c
@@ -1,6 +1,7 @@
 #include "main.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 /**
  * _printf - function used for printing any value
  * @format: Value to print along with specifiers
@@ -14,7 +15,7 @@ int _printf(const char *format, ...)
 	int *pointer_count = &count;
 
 	va_start(list, format);
-	if (format != NULL)
+	if (format)
 	{
 		while (format[i])
 		{
@@ -61,7 +62,8 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*i += 2;
 			break;
 		default:
-			++*i;
+			exit(EXIT_FAILURE);
+			*i += 2;
 			break;
 	}
 }

--- a/_printf.c
+++ b/_printf.c
@@ -14,7 +14,7 @@ int _printf(const char *format, ...)
 	int *pointer_count = &count;
 
 	va_start(list, format);
-	if (format)
+	if (format != NULL)
 	{
 		while (format[i])
 		{

--- a/_printf.c
+++ b/_printf.c
@@ -57,8 +57,8 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*i += 2;
 			break;
 		default:
-			exit(EXIT_FAILURE);
-			*i += 2;
+			*count += _putchar('%');
+			++*i;
 			break;
 	}
 }

--- a/_printf.c
+++ b/_printf.c
@@ -24,7 +24,7 @@ int _printf(const char *format, ...)
 			{
 				select_command(format, list, pointer_i, pointer_count, pointer_error);
 				if (error == 1)
-					return count;
+					return (count);
 			}
 			else
 			{

--- a/_printf.c
+++ b/_printf.c
@@ -81,7 +81,6 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			break;
 		default:
 			_putchar('%');
-			*error = 1;
 	}
 }
 /**

--- a/_printf.c
+++ b/_printf.c
@@ -57,6 +57,7 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*i += 2;
 			break;
 		case ' ':
+			*count += _putchar('%');
 			exit(EXIT_FAILURE);
 			break;
 		default:

--- a/_printf.c
+++ b/_printf.c
@@ -59,7 +59,6 @@ void select_command(const char *format, va_list list, int *i, int *count)
 		default:
 			*count += _putchar('%');
 			*count += _putchar(format[*i + 1]);
-			++*i; 
 			exit(EXIT_FAILURE);
 			break;
 	}

--- a/_printf.c
+++ b/_printf.c
@@ -59,15 +59,6 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			*count += _prints(va_arg(list, char *));
 			*i += 2;
 			break;
-		case ' ':
-			*count += _putchar('%');
-			*error = 1;
-			break;
-		case '\0':
-			*count += _putchar('%');
-			*error = 1;
-			++*i;
-			break;
 		default:
 			*count += _putchar('%');
 			*error = 1;

--- a/_printf.c
+++ b/_printf.c
@@ -47,6 +47,9 @@ int _printf(const char *format, ...)
 void select_command(const char *format, va_list list, int *i, int *count,
 		int *error)
 {
+	char *string;
+	char character;
+
 	switch (format[*i + 1])
 	{
 		case '%':
@@ -54,14 +57,23 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			*i += 2;
 			break;
 		case 'c':
-			*count += _putchar(va_arg(list, int));
+			character = va_arg(list, int);
+			if (character != 0)
+				*count += _putchar(character);
+			else
+				*error = 1;
 			*i += 2;
 			break;
 		case 's':
-			*count += _prints(va_arg(list, char *));
+			string = va_arg(list, char *);
+			if (string != NULL)
+				*count += _prints(string);
+			else
+				*error = 1;
 			*i += 2;
 			break;
 		case ' ':
+			_putchar('%');
 			*error = 1;
 			++*i;
 			break;

--- a/_printf.c
+++ b/_printf.c
@@ -24,7 +24,7 @@ int _printf(const char *format, ...)
 			{
 				select_command(format, list, pointer_i, pointer_count, pointer_error);
 				if (error == 1)
-					exit(EXIT_FAILURE);
+					return (count);
 			}
 			else
 			{

--- a/_printf.c
+++ b/_printf.c
@@ -61,6 +61,11 @@ void select_command(const char *format, va_list list, int *i, int *count,
 			*count += _prints(va_arg(list, char *));
 			*i += 2;
 			break;
+		case ' ':
+			*count += _prints(va_arg(list, char *));
+			*error = 1;
+			++*i;
+			break;
 		default:
 			*count += _putchar('%');
 			*error = 0;

--- a/_printf.c
+++ b/_printf.c
@@ -61,7 +61,7 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			exit(EXIT_FAILURE);
 			break;
 		case '\0':
-			exit(EXIT_FAILURE):
+			++*i;
 			break;
 		default:
 			*count += _putchar('%');

--- a/_printf.c
+++ b/_printf.c
@@ -23,8 +23,6 @@ int _printf(const char *format, ...)
 			if (format[i] == '%')
 			{
 				select_command(format, list, pointer_i, pointer_count, pointer_error);
-				if (error == 1)
-					return (count);
 			}
 			else
 			{

--- a/_printf.c
+++ b/_printf.c
@@ -56,6 +56,9 @@ void select_command(const char *format, va_list list, int *i, int *count)
 			*count += _prints(va_arg(list, char *));
 			*i += 2;
 			break;
+		case ' ':
+			exit(EXIT_FAILURE);
+			break;
 		default:
 			*count += _putchar('%');
 			++*i;

--- a/main.h
+++ b/main.h
@@ -3,7 +3,7 @@
 #include <stdarg.h>
 
 int _printf(const char *format, ...);
-int select_command(const char *format, va_list list, int i, int count);
+void select_command(const char *format, va_list list, int *i, int *count);
 int _putchar(char c);
 int _prints(char *s);
 int _printint(int i);

--- a/main.h
+++ b/main.h
@@ -3,7 +3,8 @@
 #include <stdarg.h>
 
 int _printf(const char *format, ...);
-void select_command(const char *format, va_list list, int *i, int *count);
+void select_command(const char *format, va_list list, int *i, int *count,
+		int *error);
 int _putchar(char c);
 int _prints(char *s);
 int _printint(int i);

--- a/main.h
+++ b/main.h
@@ -1,8 +1,11 @@
 #ifndef PRINTF_FUNC
 #define PRINTF_FUNC
+#include <stdarg.h>
 
 int _printf(const char *format, ...);
+int select_command(const char *format, va_list list, int i, int count);
 int _putchar(char c);
 int _prints(char *s);
-int _printint(int i);void _print_num(int n);
+int _printint(int i);
+void _print_num(int n);
 #endif


### PR DESCRIPTION
The switch statement from the _printf function is moved to a separate function because the number of lines of the _printf function was more than what the betty format allowed.